### PR TITLE
Add names to comments

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -24,5 +24,4 @@ $(function(){
     $('#js-upvote-form').toggleClass('asHidden')
     $('#upvote-button').toggle()
   }
-  
 });

--- a/app/assets/stylesheets/application.sass
+++ b/app/assets/stylesheets/application.sass
@@ -1,3 +1,5 @@
 @import 'foundation_and_overrides'
 
+@import 'base/*'
+
 @import 'atoms/*'

--- a/app/assets/stylesheets/atoms/_floating_form.sass
+++ b/app/assets/stylesheets/atoms/_floating_form.sass
@@ -3,8 +3,8 @@
   padding: 20px
   position: absolute
   box-shadow: 0px 0px 10px rgba(0, 0, 0, .25)
+  min-width: 300px
   &.asHidden
     display: none
   &--text
     height: 100px
-    width: 600px

--- a/app/assets/stylesheets/base/global.sass
+++ b/app/assets/stylesheets/base/global.sass
@@ -1,0 +1,3 @@
+.field_with_errors
+  input, textarea
+    border: 1px solid red

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -15,6 +15,6 @@ class CommentsController < ApplicationController
   private
 
   def comment_params
-    params.require(:comment).permit(:text)
+    params.require(:comment).permit(:text, :name)
   end
 end

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -9,6 +9,7 @@ class PostsController < ApplicationController
 
   def show
     @post = Post.find(params[:id])
+    @upvote_comment = Comment.new
   end
 
   def new
@@ -40,12 +41,14 @@ class PostsController < ApplicationController
 
   def upvote
     @post = Post.find(params[:id])
-    @post.upvote
-    @comment = @post.comments.create(comment_params)
-    respond_to do |format|
-      format.html { redirect_to @post }
-      format.js { }
+    @upvote_comment = Comment.new(comment_params.merge(post: @post))
+    if @upvote_comment.save
+      @post.upvote
+      redirect_to post_path(@post)
+    else
+      render 'show'
     end
+
   end
 
   private
@@ -55,7 +58,7 @@ class PostsController < ApplicationController
   end
 
   def comment_params
-    params.permit(:text)
+    params.require(:comment).permit(:text, :name)
   end
 
 end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -3,6 +3,7 @@ class Comment < ApplicationRecord
 
   validates :text, presence: true, length: { in: 5..1000 }
   validates :post, presence: true
+  validates :name, presence: true, length: { maximum: 255 }
 
   default_scope { order("created_at DESC") }
 end

--- a/app/views/posts/_comments.html.haml
+++ b/app/views/posts/_comments.html.haml
@@ -6,5 +6,6 @@
     = render 'comments_form', post: post
     - post.comments.each do |comment|
       .a-comment
+        %small= comment.name.present? ? comment.name : "anonymous"
         %p= comment.text
         %small= "#{time_ago_in_words(comment.created_at)} ago"

--- a/app/views/posts/_comments_form.html.haml
+++ b/app/views/posts/_comments_form.html.haml
@@ -2,6 +2,8 @@
   %h4 Add your comment
 .cell
   = form_for(Comment.new, url: post_comments_path(post.id)) do |f|
+    = f.label :name, 'Name'
+    = f.text_field :name
     = f.label :text, 'Text'
-    = f.text_field :text
+    = f.text_area :text
     = f.submit 'Save', class: 'button'

--- a/app/views/posts/_upvotes.html.haml
+++ b/app/views/posts/_upvotes.html.haml
@@ -17,7 +17,7 @@
         = f.submit 'Save', class: 'button'
         %a.button.secondary#js-cancel-upvote-button{href: 'javascript:void(0)'} Cancel
 
-- if @upvote_comment.try(:errors).present?
+- if comment.errors.present?
   :javascript
     $('#js-upvote-form').removeClass('asHidden')
     $('#upvote-button').hide()

--- a/app/views/posts/_upvotes.html.haml
+++ b/app/views/posts/_upvotes.html.haml
@@ -5,8 +5,19 @@
 
   .cell
     #js-upvote-form.a-floating-form.asHidden
-      = form_tag([:upvote, post], remote: true) do
-        = label_tag :text, 'Why are you upvoting?'
-        = text_area_tag :text, '', id: "upvote-comment-text", class: 'a-floating-form--text'
-        = button_tag 'Save', class: 'button'
+      - if comment.errors.any?
+        - comment.errors.full_messages.each do |message|
+          .callout.alert
+            = message
+      = form_for comment, :url => { :action => "upvote" }, :html => { :method => :put } do |f|
+        = f.label :name, 'Name'
+        = f.text_field :name, id: "upvote-comment-name", class: 'input'
+        = f.label :text, 'Why are you upvoting?'
+        = f.text_area :text, id: "upvote-comment-text", class: 'input a-floating-form--text'
+        = f.submit 'Save', class: 'button'
         %a.button.secondary#js-cancel-upvote-button{href: 'javascript:void(0)'} Cancel
+
+- if @upvote_comment.try(:errors).present?
+  :javascript
+    $('#js-upvote-form').removeClass('asHidden')
+    $('#upvote-button').hide()

--- a/app/views/posts/show.html.haml
+++ b/app/views/posts/show.html.haml
@@ -11,7 +11,7 @@
           .cell.small-12.small-offset-11
             %a{href: edit_post_path(@post)} Edit
           .cell.small-2
-            = render 'upvotes', post: @post
+            = render 'upvotes', post: @post, comment: @upvote_comment
           .cell.small-10
             .a-post-content
               %small= @post.categories.map(&:name).join(", ")

--- a/app/views/posts/upvote.js.erb
+++ b/app/views/posts/upvote.js.erb
@@ -1,5 +1,0 @@
-$('#js-upvote-count').html('<%= @post.upvotes %>')
-$('#upvote-comment-text').val('')
-$('#js-upvote-form').addClass('asHidden')
-$('#comments-list').replaceWith('<%= j render("comments", post: @post) %>')
-$('#upvote-button').show()

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,7 @@ Rails.application.routes.draw do
   resources :posts do
     resources :comments, only: [:create]
     member do
-      post :upvote
+      put :upvote
     end
   end
   resources :categories, only: [:show]

--- a/db/migrate/20180221130132_add_name_to_comments.rb
+++ b/db/migrate/20180221130132_add_name_to_comments.rb
@@ -1,0 +1,5 @@
+class AddNameToComments < ActiveRecord::Migration[5.1]
+  def change
+    add_column :comments, :name, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180213164041) do
+ActiveRecord::Schema.define(version: 20180221130132) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -32,6 +32,7 @@ ActiveRecord::Schema.define(version: 20180213164041) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "post_id"
+    t.string "name"
     t.index ["post_id"], name: "index_comments_on_post_id"
   end
 

--- a/spec/factories/comments.rb
+++ b/spec/factories/comments.rb
@@ -1,6 +1,7 @@
 FactoryBot.define do
   factory :comment do
     text "MyText"
+    name "Commenter name"
     association :post, factory: :post_with_categories
   end
 end

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -30,4 +30,15 @@ RSpec.describe Comment, type: :model do
     comment.text = "a" * 4
     expect(comment).not_to be_valid
   end
+
+  it 'is not valid without a name' do
+    comment.name = nil
+    expect(comment).not_to be_valid
+  end
+
+  it 'is not valid with a too long' do
+    comment.name = "a" * 256
+    expect(comment).not_to be_valid
+  end
+
 end


### PR DESCRIPTION
* Add a `name` field to the comment model
* Adapt factory and tests accordingly
* Display name field in views and forms
* On the way, tidy up the upvote form. Now no longer uses the nasty `.js.erb` file, which feels much less hacky to me.

Closes #14 