### PR TITLE
Formatting for Posts and Comments

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -38,6 +38,9 @@ gem 'foundation-rails', '~> 6.4'
 
 gem 'jquery-rails'
 
+# Add autolinks
+gem 'rails_autolink'
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -137,6 +137,8 @@ GEM
       nokogiri (>= 1.6)
     rails-html-sanitizer (1.0.3)
       loofah (~> 2.0)
+    rails_autolink (1.1.6)
+      rails (> 3.1)
     railties (5.1.4)
       actionpack (= 5.1.4)
       activesupport (= 5.1.4)
@@ -231,6 +233,7 @@ DEPENDENCIES
   puma (~> 3.7)
   rails (~> 5.1.4)
   rails-controller-testing
+  rails_autolink
   rspec-rails (~> 3.7)
   sass-rails (~> 5.0)
   selenium-webdriver

--- a/app/views/posts/_comments.html.haml
+++ b/app/views/posts/_comments.html.haml
@@ -7,5 +7,5 @@
     - post.comments.each do |comment|
       .a-comment
         %small= comment.name.present? ? comment.name : "anonymous"
-        %p= comment.text
+        = simple_format(comment.text)
         %small= "#{time_ago_in_words(comment.created_at)} ago"

--- a/app/views/posts/_comments.html.haml
+++ b/app/views/posts/_comments.html.haml
@@ -7,5 +7,5 @@
     - post.comments.each do |comment|
       .a-comment
         %small= comment.name.present? ? comment.name : "anonymous"
-        = simple_format(comment.text)
+        = simple_format(auto_link(comment.text))
         %small= "#{time_ago_in_words(comment.created_at)} ago"

--- a/app/views/posts/show.html.haml
+++ b/app/views/posts/show.html.haml
@@ -16,7 +16,7 @@
             .a-post-content
               %small= @post.categories.map(&:name).join(", ")
               %h3= @post.title
-              %p= @post.description
+              = simple_format(@post.description)
               %a{href: @post.url}= @post.url
 
       = render 'comments', post: @post

--- a/app/views/posts/show.html.haml
+++ b/app/views/posts/show.html.haml
@@ -16,7 +16,7 @@
             .a-post-content
               %small= @post.categories.map(&:name).join(", ")
               %h3= @post.title
-              = simple_format(@post.description)
+              = simple_format(auto_link(@post.description))
               %a{href: @post.url}= @post.url
 
       = render 'comments', post: @post


### PR DESCRIPTION
* Add `auto_link` to project
* Use `auto_link` and `simple_format` on post descriptions in `post#show`.
* Also use both, `auto_link` and `simple_format` on comments, since they are content that will be read as well.

Closes #13 