### PR TITLE
Friendly URLs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -41,6 +41,9 @@ gem 'jquery-rails'
 # Add autolinks
 gem 'rails_autolink'
 
+# FriendlyID for easier slugs
+gem 'friendly_id', '~> 5.1.0'
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -79,6 +79,8 @@ GEM
       railties (>= 3.1.0)
       sass (>= 3.3.0, < 3.5)
       sprockets-es6 (>= 0.9.0)
+    friendly_id (5.1.0)
+      activerecord (>= 4.0.0)
     globalid (0.4.1)
       activesupport (>= 4.2.0)
     haml (5.0.4)
@@ -225,6 +227,7 @@ DEPENDENCIES
   coffee-rails (~> 4.2)
   factory_bot_rails
   foundation-rails (~> 6.4)
+  friendly_id (~> 5.1.0)
   haml
   jbuilder (~> 2.5)
   jquery-rails

--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -1,5 +1,5 @@
 class CategoriesController < ApplicationController
   def show
-    @category = Category.find(params[:id])
+    @category = Category.friendly.find(params[:id])
   end
 end

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,14 +1,10 @@
 class PostsController < ApplicationController
   def index
-    if params[:category]
-      @posts = Category.find(params[:category]).posts.limit(50).to_a
-    else
-      @posts = Post.limit(50).to_a
-    end
+    @posts = Post.limit(50).to_a
   end
 
   def show
-    @post = Post.find(params[:id])
+    @post = Post.friendly.find(params[:id])
     @upvote_comment = Comment.new
   end
 
@@ -26,11 +22,11 @@ class PostsController < ApplicationController
   end
 
   def edit
-    @post = Post.find(params[:id])
+    @post = Post.friendly.find(params[:id])
   end
 
   def update
-    @post = Post.find(params[:id])
+    @post = Post.friendly.find(params[:id])
 
     if @post.update(post_params)
      redirect_to @post
@@ -40,7 +36,7 @@ class PostsController < ApplicationController
   end
 
   def upvote
-    @post = Post.find(params[:id])
+    @post = Post.friendly.find(params[:id])
     @upvote_comment = Comment.new(comment_params.merge(post: @post))
     if @upvote_comment.save
       @post.upvote

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -1,9 +1,10 @@
 class Category < ApplicationRecord
   extend FriendlyId
-  friendly_id :name
+  friendly_id :name, use: :slugged
 
   has_and_belongs_to_many :posts
 
   validates :name, presence: true, length: { maximum: 255 }, uniqueness: true
   validates :description, length: { maximum: 1000 }
+  validates :slug, presence: true
 end

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -1,4 +1,7 @@
 class Category < ApplicationRecord
+  extend FriendlyId
+  friendly_id :name
+
   has_and_belongs_to_many :posts
 
   validates :name, presence: true, length: { maximum: 255 }, uniqueness: true

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -1,6 +1,6 @@
 class Category < ApplicationRecord
   extend FriendlyId
-  friendly_id :name, use: :slugged
+  friendly_id :name, use: [:slugged, :history]
 
   has_and_belongs_to_many :posts
 

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -7,4 +7,8 @@ class Category < ApplicationRecord
   validates :name, presence: true, length: { maximum: 255 }, uniqueness: true
   validates :description, length: { maximum: 1000 }
   validates :slug, presence: true
+
+  def should_generate_new_friendly_id?
+    name_changed?
+  end
 end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -10,6 +10,7 @@ class Post < ApplicationRecord
   validates :url, presence: true, length: { maximum: 255 }
   validates :categories, presence: true
   validates :upvotes, numericality: { only_integer: true, greater_than_or_equal_to: 0 }
+  validates :slug, presence: true
   validate :valid_url
   
   default_scope { order("created_at DESC") }

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -2,6 +2,9 @@ class Post < ApplicationRecord
   has_and_belongs_to_many :categories
   has_many :comments, dependent: :destroy
 
+  extend FriendlyId
+  friendly_id :title, use: :slugged
+
   validates :title, presence: true, length: { in: 6..255}
   validates :description, presence: true, length: { in: 40..1000}
   validates :url, presence: true, length: { maximum: 255 }
@@ -22,5 +25,9 @@ class Post < ApplicationRecord
 
   def upvote
     update_column(:upvotes, upvotes + 1)
+  end
+
+  def normalize_friendly_id(string)
+    super[0..80]
   end
 end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -31,4 +31,8 @@ class Post < ApplicationRecord
   def normalize_friendly_id(string)
     super[0..80]
   end
+
+  def should_generate_new_friendly_id?
+    title_changed?
+  end
 end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -3,7 +3,7 @@ class Post < ApplicationRecord
   has_many :comments, dependent: :destroy
 
   extend FriendlyId
-  friendly_id :title, use: :slugged
+  friendly_id :title, use: [:slugged, :history]
 
   validates :title, presence: true, length: { in: 6..255}
   validates :description, presence: true, length: { in: 40..1000}

--- a/app/views/shared/_sidebar.html.haml
+++ b/app/views/shared/_sidebar.html.haml
@@ -2,6 +2,6 @@
   %ul.vertical.menu
     %li
       %a{href: '/'} All
-    - Category.friendly.all.each do |category|
+    - Category.all.each do |category|
       %li
         = link_to category.name, category

--- a/app/views/shared/_sidebar.html.haml
+++ b/app/views/shared/_sidebar.html.haml
@@ -2,6 +2,6 @@
   %ul.vertical.menu
     %li
       %a{href: '/'} All
-    - Category.all.each.each do |category|
+    - Category.friendly.all.each do |category|
       %li
         = link_to category.name, category

--- a/config/initializers/friendly_id.rb
+++ b/config/initializers/friendly_id.rb
@@ -1,0 +1,88 @@
+# FriendlyId Global Configuration
+#
+# Use this to set up shared configuration options for your entire application.
+# Any of the configuration options shown here can also be applied to single
+# models by passing arguments to the `friendly_id` class method or defining
+# methods in your model.
+#
+# To learn more, check out the guide:
+#
+# http://norman.github.io/friendly_id/file.Guide.html
+
+FriendlyId.defaults do |config|
+  # ## Reserved Words
+  #
+  # Some words could conflict with Rails's routes when used as slugs, or are
+  # undesirable to allow as slugs. Edit this list as needed for your app.
+  config.use :reserved
+
+  config.reserved_words = %w(new edit index session login logout users admin
+    stylesheets assets javascripts images)
+
+  #  ## Friendly Finders
+  #
+  # Uncomment this to use friendly finders in all models. By default, if
+  # you wish to find a record by its friendly id, you must do:
+  #
+  #    MyModel.friendly.find('foo')
+  #
+  # If you uncomment this, you can do:
+  #
+  #    MyModel.find('foo')
+  #
+  # This is significantly more convenient but may not be appropriate for
+  # all applications, so you must explicity opt-in to this behavior. You can
+  # always also configure it on a per-model basis if you prefer.
+  #
+  # Something else to consider is that using the :finders addon boosts
+  # performance because it will avoid Rails-internal code that makes runtime
+  # calls to `Module.extend`.
+  #
+  # config.use :finders
+  #
+  # ## Slugs
+  #
+  # Most applications will use the :slugged module everywhere. If you wish
+  # to do so, uncomment the following line.
+  #
+  # config.use :slugged
+  #
+  # By default, FriendlyId's :slugged addon expects the slug column to be named
+  # 'slug', but you can change it if you wish.
+  #
+  # config.slug_column = 'slug'
+  #
+  # When FriendlyId can not generate a unique ID from your base method, it appends
+  # a UUID, separated by a single dash. You can configure the character used as the
+  # separator. If you're upgrading from FriendlyId 4, you may wish to replace this
+  # with two dashes.
+  #
+  # config.sequence_separator = '-'
+  #
+  #  ## Tips and Tricks
+  #
+  #  ### Controlling when slugs are generated
+  #
+  # As of FriendlyId 5.0, new slugs are generated only when the slug field is
+  # nil, but if you're using a column as your base method can change this
+  # behavior by overriding the `should_generate_new_friendly_id` method that
+  # FriendlyId adds to your model. The change below makes FriendlyId 5.0 behave
+  # more like 4.0.
+  #
+  # config.use Module.new {
+  #   def should_generate_new_friendly_id?
+  #     slug.blank? || <your_column_name_here>_changed?
+  #   end
+  # }
+  #
+  # FriendlyId uses Rails's `parameterize` method to generate slugs, but for
+  # languages that don't use the Roman alphabet, that's not usually sufficient.
+  # Here we use the Babosa library to transliterate Russian Cyrillic slugs to
+  # ASCII. If you use this, don't forget to add "babosa" to your Gemfile.
+  #
+  # config.use Module.new {
+  #   def normalize_friendly_id(text)
+  #     text.to_slug.normalize! :transliterations => [:russian, :latin]
+  #   end
+  # }
+end

--- a/db/migrate/20180222131221_create_friendly_id_slugs.rb
+++ b/db/migrate/20180222131221_create_friendly_id_slugs.rb
@@ -1,0 +1,15 @@
+class CreateFriendlyIdSlugs < ActiveRecord::Migration[5.1]
+  def change
+    create_table :friendly_id_slugs do |t|
+      t.string   :slug,           :null => false
+      t.integer  :sluggable_id,   :null => false
+      t.string   :sluggable_type, :limit => 50
+      t.string   :scope
+      t.datetime :created_at
+    end
+    add_index :friendly_id_slugs, :sluggable_id
+    add_index :friendly_id_slugs, [:slug, :sluggable_type]
+    add_index :friendly_id_slugs, [:slug, :sluggable_type, :scope], :unique => true
+    add_index :friendly_id_slugs, :sluggable_type
+  end
+end

--- a/db/migrate/20180222135018_add_slug_to_categories.rb
+++ b/db/migrate/20180222135018_add_slug_to_categories.rb
@@ -1,0 +1,6 @@
+class AddSlugToCategories < ActiveRecord::Migration[5.1]
+  def change
+    add_column :categories, :slug, :string
+    add_index :categories, :slug, unique: true
+  end
+end

--- a/db/migrate/20180222141637_add_slug_to_posts.rb
+++ b/db/migrate/20180222141637_add_slug_to_posts.rb
@@ -1,0 +1,6 @@
+class AddSlugToPosts < ActiveRecord::Migration[5.1]
+  def change
+    add_column :posts, :slug, :string
+    add_index :posts, :slug, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180222135018) do
+ActiveRecord::Schema.define(version: 20180222141637) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -58,6 +58,8 @@ ActiveRecord::Schema.define(version: 20180222135018) do
     t.integer "upvotes", default: 0
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "slug"
+    t.index ["slug"], name: "index_posts_on_slug", unique: true
   end
 
   add_foreign_key "comments", "posts"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180221155000) do
+ActiveRecord::Schema.define(version: 20180222131221) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -35,6 +35,18 @@ ActiveRecord::Schema.define(version: 20180221155000) do
     t.bigint "post_id"
     t.string "name"
     t.index ["post_id"], name: "index_comments_on_post_id"
+  end
+
+  create_table "friendly_id_slugs", force: :cascade do |t|
+    t.string "slug", null: false
+    t.integer "sluggable_id", null: false
+    t.string "sluggable_type", limit: 50
+    t.string "scope"
+    t.datetime "created_at"
+    t.index ["slug", "sluggable_type", "scope"], name: "index_friendly_id_slugs_on_slug_and_sluggable_type_and_scope", unique: true
+    t.index ["slug", "sluggable_type"], name: "index_friendly_id_slugs_on_slug_and_sluggable_type"
+    t.index ["sluggable_id"], name: "index_friendly_id_slugs_on_sluggable_id"
+    t.index ["sluggable_type"], name: "index_friendly_id_slugs_on_sluggable_type"
   end
 
   create_table "posts", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180222131221) do
+ActiveRecord::Schema.define(version: 20180222135018) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -20,6 +20,8 @@ ActiveRecord::Schema.define(version: 20180222131221) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.text "description"
+    t.string "slug"
+    t.index ["slug"], name: "index_categories_on_slug", unique: true
   end
 
   create_table "categories_posts", id: false, force: :cascade do |t|

--- a/spec/models/category_spec.rb
+++ b/spec/models/category_spec.rb
@@ -31,4 +31,16 @@ RSpec.describe Category, type: :model do
     duplicate_category = FactoryBot.build(:category, name: unique_categroy.name)
     expect(duplicate_category).not_to be_valid
   end
+
+  describe 'slug' do
+    let!(:category) { FactoryBot.create(:category) }
+
+    it 'updates the slug if the name was changed' do
+      new_name = 'cars'
+      category.name = new_name
+      category.save
+
+      expect(category.slug).to eq(new_name.parameterize)
+    end
+  end
 end

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -85,4 +85,16 @@ RSpec.describe Post, type: :model do
     end
   end
 
+  describe 'slug' do
+    let(:post) { FactoryBot.create(:post_with_categories) }
+
+    it 'updates the slug if the name was changed' do
+      new_title = "New title for post"
+      post.title = new_title
+      post.save
+
+      expect(post.slug).to eq(new_title.parameterize)
+    end
+  end
+
 end


### PR DESCRIPTION
* Add [FriendlyId](https://github.com/norman/friendly_id) to help dealing with slugs
* Use slugs for categories and posts, leading to nicer urls
  * post slugs are limited to 80 characters, so in case we have a post with a long and duplicate title, we still have a reasonable length for the url (80 characters + `https://decent-organisations.tld/posts/` + 36 characters UUID generated by FriendlyId in case of duplicate slugs)

**NOTE**: After the migrations have run, all existing posts and categories need to be touched and saved once to populate the slugs. Is it sufficient to run `Category.find_each(&:save)` and `Post.find_each(&:save)` in the console or do we need a rake script (or something else, I'm honestly not too sure what the best approach would be)?

Closes #10